### PR TITLE
v1.1.0 - Duplicator Preview & UX Improvements

### DIFF
--- a/client/duplicator_preview.lua
+++ b/client/duplicator_preview.lua
@@ -1,0 +1,276 @@
+-- client/duplicator_preview.lua
+-- Preview generation logic for duplicator mode
+-- Shows a preview of what will be duplicated before the user clicks "Duplicate"
+--
+-- Dependencies: shared/constants.lua (PREVIEW_LIMIT, AMT.VALID_DUPLICATION_TYPES)
+-- Uses the shared AMT.previewElements table (same as Generator preview)
+-- Only one preview can be active at a time (Generator OR Duplicator)
+
+-- UI Constants
+local PREVIEW_ALPHA = 150  -- Transparency level for preview elements (0-255)
+
+-- Alias to the shared clearPreviews function for consistency
+-- clearPreviews() is defined in gui_preview.lua and works for both modes
+function clearDuplicatorPreview()
+	clearPreviews()
+end
+
+-- Track selected elements for preview update
+local dupState = {
+	element1 = nil,
+	element2 = nil,
+	amount = nil,
+	element1Pos = nil,
+	element2Pos = nil,
+	element1Rot = nil,
+	element2Rot = nil,
+	type1 = nil,
+	type2 = nil
+}
+
+-- Helper to check if position changed
+local function positionChanged(pos1, pos2)
+	if not pos1 or not pos2 then return true end
+	return pos1.x ~= pos2.x or pos1.y ~= pos2.y or pos1.z ~= pos2.z
+end
+
+-- Helper to check if rotation changed
+local function rotationChanged(rot1, rot2)
+	if not rot1 or not rot2 then return true end
+	return rot1.x ~= rot2.x or rot1.y ~= rot2.y or rot1.z ~= rot2.z
+end
+
+-- Reset tracking state (called when switching windows or clearing)
+local function resetDuplicatorTrackingState()
+	dupState.element1 = nil
+	dupState.element2 = nil
+	dupState.amount = nil
+	dupState.element1Pos = nil
+	dupState.element2Pos = nil
+	dupState.element1Rot = nil
+	dupState.element2Rot = nil
+	dupState.type1 = nil
+	dupState.type2 = nil
+end
+
+-- Update the duplicator preview based on selected elements and copy count
+local function updateDuplicatorPreview()
+	-- Guard: Check if GUI is initialized
+	if not AMT.gui[2] or not isElement(AMT.gui[2].window) then
+		return
+	end
+
+	-- Only update when on duplicator window (window 2)
+	if AMT.currentWindow ~= 2 or not guiGetVisible(AMT.gui[2].window) then
+		return
+	end
+
+	-- Validate elements are selected
+	if not isElement(AMT.duplicateElement[1]) or not isElement(AMT.duplicateElement[2]) then
+		clearDuplicatorPreview()
+		return
+	end
+
+	-- Validate element types
+	local type1 = getElementType(AMT.duplicateElement[1])
+	local type2 = getElementType(AMT.duplicateElement[2])
+	if not AMT.VALID_DUPLICATION_TYPES[type1] or not AMT.VALID_DUPLICATION_TYPES[type2] then
+		clearDuplicatorPreview()
+		return
+	end
+
+	-- Guard: Check if dup_amount GUI element exists
+	if not AMT.gui.dup_amount or not isElement(AMT.gui.dup_amount) then
+		return
+	end
+
+	-- Get copies count
+	local copies = tonumber(guiGetText(AMT.gui.dup_amount))
+	if not copies or copies <= 0 then
+		clearDuplicatorPreview()
+		return
+	end
+
+	-- Calculate duplication parameters
+	local px, py, pz = getElementPosition(AMT.duplicateElement[1])
+	local rx, ry, rz = getElementRotation(AMT.duplicateElement[1])
+	local px2, py2, pz2 = getElementPosition(AMT.duplicateElement[2])
+	local rx2, ry2, rz2 = getElementRotation(AMT.duplicateElement[2])
+	
+	local posDiffX, posDiffY, posDiffZ = px2 - px, py2 - py, pz2 - pz
+	local rotDiffX, rotDiffY, rotDiffZ = rx2 - rx, ry2 - ry, rz2 - rz
+	
+	local model1 = getElementModel(AMT.duplicateElement[1])
+	local model2 = getElementModel(AMT.duplicateElement[2])
+
+	-- Limit preview to reasonable count to prevent performance issues
+	local previewCopies = math.min(copies, PREVIEW_LIMIT)
+
+	-- Optimization: Check if we can reuse existing preview elements
+	-- We reuse if the count is the same and the element types haven't changed
+	local reuseElements = false
+	if #AMT.previewElements == previewCopies and type1 == dupState.type1 and type2 == dupState.type2 then
+		reuseElements = true
+	else
+		-- If we can't reuse, clear everything first
+		clearDuplicatorPreview()
+	end
+
+	-- Update tracking types
+	dupState.type1 = type1
+	dupState.type2 = type2
+
+	-- Generate or update preview elements
+	for i = 1, previewCopies do
+		local model
+		if i % 2 == 0 then
+			model = model1
+		else
+			model = model2
+		end
+
+		local newPosX = px2 + posDiffX * i
+		local newPosY = py2 + posDiffY * i
+		local newPosZ = pz2 + posDiffZ * i
+		local newRotX = rx2 + rotDiffX * i
+		local newRotY = ry2 + rotDiffY * i
+		local newRotZ = rz2 + rotDiffZ * i
+
+		if reuseElements then
+			-- Update existing element
+			local previewElement = AMT.previewElements[i]
+			if isElement(previewElement) then
+				setElementPosition(previewElement, newPosX, newPosY, newPosZ)
+				setElementRotation(previewElement, newRotX, newRotY, newRotZ)
+				setElementModel(previewElement, model)
+			end
+		else
+			-- Create new preview element based on type
+			local previewElement
+			-- Determine type for this specific copy (alternating)
+			local currentType = (i % 2 == 0) and type1 or type2
+			
+			if currentType == "object" then
+				previewElement = createObject(model, newPosX, newPosY, newPosZ, newRotX, newRotY, newRotZ)
+			elseif currentType == "vehicle" then
+				previewElement = createVehicle(model, newPosX, newPosY, newPosZ, newRotX, newRotY, newRotZ)
+			elseif currentType == "ped" then
+				previewElement = createPed(0, newPosX, newPosY, newPosZ)  -- Peds use skin ID, not model
+				if previewElement then
+					setElementModel(previewElement, model)
+					setElementRotation(previewElement, newRotX, newRotY, newRotZ)
+				end
+			end
+
+			if previewElement then
+				setElementDimension(previewElement, getElementDimension(getLocalPlayer()))
+				setElementAlpha(previewElement, PREVIEW_ALPHA)  -- Transparent preview
+				setElementCollisionsEnabled(previewElement, false)  -- No collision for preview
+				
+				-- For vehicles, freeze them so they don't fall
+				if currentType == "vehicle" then
+					setElementFrozen(previewElement, true)
+				end
+				
+				AMT.previewElements[#AMT.previewElements + 1] = previewElement
+			end
+		end
+	end
+
+	-- Show warning if preview is limited
+	if AMT.gui.dup_button and isElement(AMT.gui.dup_button) then
+		if copies > PREVIEW_LIMIT then
+			-- Update button to show warning
+			guiSetProperty(AMT.gui.dup_button, "NormalTextColour", "FFFF0000")
+			guiSetText(AMT.gui.dup_button, "Duplicate (" .. copies .. " copies)")
+		else
+			-- Reset button to normal
+			guiSetProperty(AMT.gui.dup_button, "NormalTextColour", "FFFFFFFF")
+			guiSetText(AMT.gui.dup_button, "Duplicate")
+		end
+	end
+end
+
+-- Monitor for changes that should trigger preview update
+local wasDupVisible = false
+addEventHandler("onClientRender", root, function()
+	-- Guard: Check if GUI is initialized
+	if not AMT.gui[2] or not isElement(AMT.gui[2].window) then
+		return
+	end
+	
+	-- Handle visibility changes first
+	local isVisible = guiGetVisible(AMT.gui[2].window) and AMT.currentWindow == 2
+	
+	if isVisible ~= wasDupVisible then
+		if isVisible then
+			-- Window just opened - reset tracking state and trigger preview
+			resetDuplicatorTrackingState()
+			updateDuplicatorPreview()
+		else
+			-- Window just closed - clear preview and reset tracking
+			clearDuplicatorPreview()
+			resetDuplicatorTrackingState()
+		end
+		wasDupVisible = isVisible
+		return -- Exit early after visibility change
+	end
+
+	-- Only process element changes when visible
+	if not isVisible then return end
+
+	-- Guard: Check if dup_amount exists
+	if not AMT.gui.dup_amount or not isElement(AMT.gui.dup_amount) then
+		return
+	end
+
+	local needsUpdate = false
+
+	-- Check if elements changed
+	if AMT.duplicateElement[1] ~= dupState.element1 then
+		dupState.element1 = AMT.duplicateElement[1]
+		needsUpdate = true
+	end
+	if AMT.duplicateElement[2] ~= dupState.element2 then
+		dupState.element2 = AMT.duplicateElement[2]
+		needsUpdate = true
+	end
+
+	-- Check if amount changed
+	local currentAmount = guiGetText(AMT.gui.dup_amount)
+	if currentAmount ~= dupState.amount then
+		dupState.amount = currentAmount
+		needsUpdate = true
+	end
+
+	-- Check if element positions/rotations changed (for real-time preview)
+	if isElement(AMT.duplicateElement[1]) then
+		local x, y, z = getElementPosition(AMT.duplicateElement[1])
+		local rx, ry, rz = getElementRotation(AMT.duplicateElement[1])
+		local newPos = {x = x, y = y, z = z}
+		local newRot = {x = rx, y = ry, z = rz}
+		
+		if positionChanged(dupState.element1Pos, newPos) or rotationChanged(dupState.element1Rot, newRot) then
+			dupState.element1Pos = newPos
+			dupState.element1Rot = newRot
+			needsUpdate = true
+		end
+	end
+
+	if isElement(AMT.duplicateElement[2]) then
+		local x, y, z = getElementPosition(AMT.duplicateElement[2])
+		local rx, ry, rz = getElementRotation(AMT.duplicateElement[2])
+		local newPos = {x = x, y = y, z = z}
+		local newRot = {x = rx, y = ry, z = rz}
+		
+		if positionChanged(dupState.element2Pos, newPos) or rotationChanged(dupState.element2Rot, newRot) then
+			dupState.element2Pos = newPos
+			dupState.element2Rot = newRot
+			needsUpdate = true
+		end
+	end
+
+	if needsUpdate then
+		updateDuplicatorPreview()
+	end
+end)

--- a/client/gui_events.lua
+++ b/client/gui_events.lua
@@ -16,6 +16,8 @@ function()
 	if(AMT.hElements[1] ~= nil)then
 		triggerServerEvent("requestDestroyElements", getLocalPlayer(), AMT.hElements)
 	end
+	-- Clean up all preview elements (shared between Generator and Duplicator)
+	clearPreviews()
 end)
 
 addCommandHandler("des",

--- a/client/gui_generator.lua
+++ b/client/gui_generator.lua
@@ -236,6 +236,12 @@ function startGenerating()
 		-- Pass the CALCULATED rotation (rotX, rotY, rotZ) which includes the twist if applicable
 		triggerServerEvent("onRequestGenerate", getLocalPlayer(), AMT.selectedElement, rotX, rotY, rotZ, loops, radius, objects, offset, AMT.img[AMT.selectedElement].selectedCenter, AMT.img[AMT.selectedElement].selectedDir, addX, addY, addZ, conX, conY, conZ, nil, nil, nil, isCurvedLoop, origRotX, origRotY, origRotZ, twistAmountX, twistAmountY, twistAmountZ)
 
+		-- Disable twist fields after generating (lock the curved rotation values)
+		-- Values are kept visible but not editable until Save
+		guiSetEnabled(AMT.gui.twist_rotX_field, false)
+		guiSetEnabled(AMT.gui.twist_rotY_field, false)
+		guiSetEnabled(AMT.gui.twist_rotZ_field, false)
+
 		-- Switch to edit/save mode (updates button text and highlighting)
 		-- GUIBuilder.setGenerateMode(false) -- MOVED: Now handled in sendBackRequestedElements
 		guiSetEnabled(AMT.gui.gen_button, false)
@@ -278,6 +284,14 @@ function startGenerating()
 		guiSetText(AMT.gui.conrot_rotX_field, "0")
 		guiSetText(AMT.gui.conrot_rotY_field, "0")
 		guiSetText(AMT.gui.conrot_rotZ_field, "0")
+
+		-- Re-enable and reset twist fields on Save
+		guiSetEnabled(AMT.gui.twist_rotX_field, true)
+		guiSetEnabled(AMT.gui.twist_rotY_field, true)
+		guiSetEnabled(AMT.gui.twist_rotZ_field, true)
+		guiSetText(AMT.gui.twist_rotX_field, "0")
+		guiSetText(AMT.gui.twist_rotY_field, "0")
+		guiSetText(AMT.gui.twist_rotZ_field, "0")
 
 		-- Switch back to preview/generate mode (updates button text and highlighting)
 		GUIBuilder.setGenerateMode(true)

--- a/client/gui_init.lua
+++ b/client/gui_init.lua
@@ -277,7 +277,24 @@ function()
 			if(isElement(AMT.duplicateElement[1]) and isElement(AMT.duplicateElement[2]) and copies)then
 				-- Clear preview before triggering actual duplication
 				clearDuplicatorPreview()
-				triggerServerEvent("onAMTExtendedRequestDuplicate", getLocalPlayer(), AMT.duplicateElement[1], AMT.duplicateElement[2], copies)
+				-- Get current client-side positions/rotations (may differ from server if moved in editor)
+				local px1, py1, pz1 = getElementPosition(AMT.duplicateElement[1])
+				local rx1, ry1, rz1 = getElementRotation(AMT.duplicateElement[1])
+				local px2, py2, pz2 = getElementPosition(AMT.duplicateElement[2])
+				local rx2, ry2, rz2 = getElementRotation(AMT.duplicateElement[2])
+				local model1 = getElementModel(AMT.duplicateElement[1])
+				local model2 = getElementModel(AMT.duplicateElement[2])
+				local elementData = {
+					element1 = AMT.duplicateElement[1],
+					element2 = AMT.duplicateElement[2],
+					pos1 = {x = px1, y = py1, z = pz1},
+					rot1 = {x = rx1, y = ry1, z = rz1},
+					pos2 = {x = px2, y = py2, z = pz2},
+					rot2 = {x = rx2, y = ry2, z = rz2},
+					model1 = model1,
+					model2 = model2
+				}
+				triggerServerEvent("onAMTExtendedRequestDuplicate", getLocalPlayer(), elementData, copies)
 				-- Clear element selection for fresh state
 				AMT.duplicateElement[1] = nil
 				AMT.duplicateElement[2] = nil

--- a/client/gui_init.lua
+++ b/client/gui_init.lua
@@ -215,7 +215,7 @@ function()
 	-- Visibility Watcher: Automatically handle preview state when window opens/closes
 	-- This replaces the manual handlers and fixes the bug where clicking the background destroyed previews
 	local wasVisible = false
-	addEventHandler("onClientRender", root, function()
+	addEventHandler("onClientRender", getRootElement(), function()
 		if not AMT.gui[1] or not isElement(AMT.gui[1].window) then return end
 		
 		local isVisible = guiGetVisible(AMT.gui[1].window)
@@ -224,7 +224,14 @@ function()
 			if isVisible then
 				-- Window just opened
 				if AMT.currentWindow == 1 then
-					previewUpdate()
+					-- Only show preview if editor has an element selected
+					local editorElement = exports.editor_main:getSelectedElement()
+					if editorElement and editorElement ~= false and getElementType(editorElement) == "object" then
+						previewUpdate()
+					else
+						-- No element selected in editor, clear any stale selection
+						clearPreviews()
+					end
 				end
 			else
 				-- Window just closed
@@ -259,6 +266,7 @@ function()
 	local amount_width = 75
 	local amount_height = 20
 	AMT.gui.dup_amount = guiCreateEdit(AMT.gui[2].window_width/2 - amount_width/2, 190, amount_width, amount_height, "5", false, AMT.gui[2].window)
+	guiSetProperty(AMT.gui.dup_amount, "ValidationString", "^[0-9]*$") -- Only allow integers
 	AMT.gui.dup_amount_title = guiCreateLabel(AMT.gui[2].window_width/2 - amount_width - 10, 190, 100, 25, "Copies: ", false, AMT.gui[2].window)
 	guiSetEnabled(AMT.gui.dup_amount_title, false)
 
@@ -267,7 +275,14 @@ function()
 		function()
 			local copies = tonumber(guiGetText(AMT.gui.dup_amount))
 			if(isElement(AMT.duplicateElement[1]) and isElement(AMT.duplicateElement[2]) and copies)then
-				triggerServerEvent("onClientRequestDuplicate", getLocalPlayer(), AMT.duplicateElement[1], AMT.duplicateElement[2], copies)
+				-- Clear preview before triggering actual duplication
+				clearDuplicatorPreview()
+				triggerServerEvent("onAMTExtendedRequestDuplicate", getLocalPlayer(), AMT.duplicateElement[1], AMT.duplicateElement[2], copies)
+				-- Clear element selection for fresh state
+				AMT.duplicateElement[1] = nil
+				AMT.duplicateElement[2] = nil
+				guiSetText(AMT.gui.element1, "Select 1st element")
+				guiSetText(AMT.gui.element2, "Select 2nd element")
 			elseif(not copies)then
 				outputChatBox("#FF2525[AMT ERROR]: #FFFFFFCopies value is not a valid number.", 255, 25, 25, true)
 			else

--- a/meta.xml
+++ b/meta.xml
@@ -1,5 +1,5 @@
 <meta>
-	<info author="Arezu" version="1.0.0" type="script" name="AMT Extended" description="Arezu's Mapping Toolbox - Extended Edition" />
+	<info author="Arezu" version="1.1.0" type="script" name="AMT Extended" description="Arezu's Mapping Toolbox - Extended Edition" />
 
 	<!-- Shared modules (used by both client and server) -->
 	<script src="shared/constants.lua" type="shared" />

--- a/meta.xml
+++ b/meta.xml
@@ -15,6 +15,7 @@
 	<script src="client/gui_preview.lua" type="client" />
 	<script src="client/element_manipulation.lua" type="client" />
 	<script src="client/gui_events.lua" type="client" />
+	<script src="client/duplicator_preview.lua" type="client" />
 
 	<!-- Server modules -->
 	<script src="server/generation.lua" type="server" />

--- a/server/duplication.lua
+++ b/server/duplication.lua
@@ -1,12 +1,23 @@
 -- server/duplication.lua
 -- Element duplication logic
 
-addEvent("onClientRequestDuplicate", true)
-addEventHandler("onClientRequestDuplicate", getRootElement(),
+addEvent("onAMTExtendedRequestDuplicate", true)
+addEventHandler("onAMTExtendedRequestDuplicate", getRootElement(),
 function(element1, element2, copies)
 	-- Validate elements exist
 	if not isElement(element1) or not isElement(element2) then
 		outputChatBox("[AMT ERROR]: Invalid elements selected.", source, 255, 25, 25, true)
+		return
+	end
+
+	-- Validate copies count (prevent server crashes from excessive requests)
+	if not copies or copies <= 0 then
+		outputChatBox("[AMT ERROR]: Invalid copy count.", source, 255, 25, 25, true)
+		return
+	end
+	if copies > MAX_SERVER_GENERATION_OBJECTS then
+		outputDebugString("AMT ERROR: Duplication count exceeds server limit: " .. copies .. " > " .. MAX_SERVER_GENERATION_OBJECTS, 1)
+		outputChatBox("[AMT ERROR]: Too many copies requested (" .. copies .. "). Maximum is " .. MAX_SERVER_GENERATION_OBJECTS .. ".", source, 255, 25, 25, true)
 		return
 	end
 

--- a/server/duplication.lua
+++ b/server/duplication.lua
@@ -3,7 +3,16 @@
 
 addEvent("onAMTExtendedRequestDuplicate", true)
 addEventHandler("onAMTExtendedRequestDuplicate", getRootElement(),
-function(element1, element2, copies)
+function(elementData, copies)
+	-- Validate element data
+	if not elementData or type(elementData) ~= "table" then
+		outputChatBox("[AMT ERROR]: Invalid element data.", source, 255, 25, 25, true)
+		return
+	end
+
+	local element1 = elementData.element1
+	local element2 = elementData.element2
+
 	-- Validate elements exist
 	if not isElement(element1) or not isElement(element2) then
 		outputChatBox("[AMT ERROR]: Invalid elements selected.", source, 255, 25, 25, true)
@@ -29,14 +38,15 @@ function(element1, element2, copies)
 		return
 	end
 
-	local px, py, pz = getElementPosition(element1)
-	local rx, ry, rz = getElementRotation(element1)
-	local px2, py2, pz2 = getElementPosition(element2)
-	local rx2, ry2, rz2 = getElementRotation(element2)
+	-- Use client-provided positions/rotations (accounts for unsaved editor movements)
+	local px, py, pz = elementData.pos1.x, elementData.pos1.y, elementData.pos1.z
+	local rx, ry, rz = elementData.rot1.x, elementData.rot1.y, elementData.rot1.z
+	local px2, py2, pz2 = elementData.pos2.x, elementData.pos2.y, elementData.pos2.z
+	local rx2, ry2, rz2 = elementData.rot2.x, elementData.rot2.y, elementData.rot2.z
 	local posDiffX, posDiffY, posDiffZ = px2 - px, py2 - py, pz2 - pz
 	local rotDiffX, rotDiffY, rotDiffZ = rx2 - rx, ry2 - ry, rz2 - rz
-	local model1 = getElementModel(element1)
-	local model2 = getElementModel(element2)
+	local model1 = elementData.model1
+	local model2 = elementData.model2
 	local elementList = {}
 
 	-- Performance optimization: Cache element counts at start for both models

--- a/shared/constants.lua
+++ b/shared/constants.lua
@@ -1,7 +1,7 @@
 -- shared/constants.lua
 -- Global constants used across the application
 
-VERSION = "1.0.0"  -- Keep in sync with meta.xml <info> tag
+VERSION = "1.1.0"  -- Keep in sync with meta.xml <info> tag
 PI = math.pi
 FOV = 0.01  -- Size of image relative to 3d distance
 MIN_RADIUS = 1  -- Minimal allowed radius to generate with

--- a/shared/constants.lua
+++ b/shared/constants.lua
@@ -18,11 +18,18 @@ AMT.KEY = {}
 AMT.hElements = {}
 AMT.elementList = {}
 AMT.duplicateElement = {}
-AMT.previewElements = {}
+AMT.previewElements = {}  -- Shared preview elements (used by both Generator and Duplicator)
 AMT.originalBaseRotation = {x = 0, y = 0, z = 0}
 AMT.VALID_DUPLICATION_TYPES = {
 	["object"] = true,
 	["vehicle"] = true,
 	["ped"] = true
+}
+
+-- Models with special default arrow directions
+-- center = Red arrow (selectedCenter), dir = Green arrow (selectedDir)
+AMT.SPECIAL_ARROW_MODELS = {
+	[7657] = { center = 6, dir = 1 },  -- Backward, Up
+	[982]  = { center = 6, dir = 1 }   -- Backward, Up
 }
 


### PR DESCRIPTION
## Summary
This release adds a real-time preview system for the Duplicator and several UX improvements contributed by Corrupt.

## New Features
- **Duplicator Preview System** — Real-time visual preview of duplicated elements before committing
- **Arrow Direction Labels on Hover** *(Corrupt)* — Direction labels (UP, DOWN, etc.) appear when hovering over manipulation arrows
- **Special Arrow Defaults for Specific Models** *(Corrupt)* — Objects 7657 and 982 now use custom default arrow directions

## Improvements
- **Twist Fields Auto-Reset** *(Corrupt)* — Twist rotation fields reset to 0 when selecting a new object or after saving
- **Twist Fields Lock on Generate** — Fields disabled during generation, re-enabled on save
- **Duplicator Input Validation** — Copy count field accepts only numbers
- **Improved Duplication Data Handling** — Client sends position/rotation data, fixing unsaved editor movements not reflecting
- **Server-Side Duplication Limits** — Added validation with max limit enforcement

## Bug Fixes
- Fixed preview showing stale elements when reopening Generator with no selection
- Fixed preview/arrow data persisting incorrectly when switching windows
- Proper cleanup of previews and state when closing or switching tabs

## Version
- Bumped to `1.1.0` in both `meta.xml` and `shared/constants.lua`